### PR TITLE
Upgrading requests to fix CVE-2025-50182 and CVE-2024-47081

### DIFF
--- a/files/lambda-artifacts/gitlab/requirements.txt
+++ b/files/lambda-artifacts/gitlab/requirements.txt
@@ -1,2 +1,2 @@
 compress_json==1.1.0
-requests==2.32.3
+requests==2.32.5

--- a/files/lambda-artifacts/okta/requirements.txt
+++ b/files/lambda-artifacts/okta/requirements.txt
@@ -1,2 +1,2 @@
 compress_json==1.1.0
-requests==2.32.3
+requests==2.32.5

--- a/files/lambda-artifacts/terraform-cloud/requirements.txt
+++ b/files/lambda-artifacts/terraform-cloud/requirements.txt
@@ -1,2 +1,2 @@
 compress_json==1.1.0
-requests==2.32.3
+requests==2.32.5


### PR DESCRIPTION
## :hammer_and_wrench: Summary

The AWS Inspector findings show 2 Medium Severity findings for CVE-2025-50182 - urllib3 and CVE-2024-47081 - requests. Therefore, requests library should be upgraded to version >=2.32.4

## :rocket: Motivation

It resolves the AWS Inspector findings and resolves the CVE.

## :pencil: Additional Information

<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to online docs or images that may help with reviewing the PR. -->
